### PR TITLE
Rename "The Adventurers' Omnibus" to "Adventures Omnibus"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# AvO: The Adventurers' Omnibus
+# AvO: Adventures Omnibus
 
-AvO: The Adventurers' Omnibus is a collection of small adventure games.
+AvO: Adventures Omnibus is a collection of small adventure games.
 
 Original code was based on [an unfinished Ludum Dare 48 game](https://github.com/shaunanoordin/ludumdare-48), [CNY2021](https://github.com/shaunanoordin/cny2021), and [AvO mk2](https://github.com/shaunanoordin/avo-adventure-mk2/).
 

--- a/index.html
+++ b/index.html
@@ -2,15 +2,15 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>AvO: The Adventurers' Omnibus</title>
-<meta name="description" content="AvO: The Adventurers' Omnibus is a collection of small adventure games.">
+<title>AvO: Adventures Omnibus</title>
+<meta name="description" content="AvO: Adventures Omnibus is a collection of small adventure games.">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="theme-color" content="#cc4444">
 <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:300" rel="stylesheet">
 <link href="./app/main.css" rel="stylesheet">
 <script src="./app/main.js"></script>
-<meta property="og:title" content="AvO: The Adventurers' Omnibus">
-<meta property="og:description" content="AvO: The Adventurers' Omnibus is a collection of small adventure games.">
+<meta property="og:title" content="AvO: Adventures Omnibus">
+<meta property="og:description" content="AvO: Adventures Omnibus is a collection of small adventure games.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="">
 <meta property="og:image" content="">
@@ -20,14 +20,14 @@
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@darke_shard">
 <meta name="twitter:creator" content="@darke_shard">
-<meta name="twitter:title" content="AvO: The Adventurers' Omnibus">
-<meta name="twitter:description" content="AvO: The Adventurers' Omnibus is a collection of small adventure games.">
+<meta name="twitter:title" content="AvO: Adventures Omnibus">
+<meta name="twitter:description" content="AvO: Adventures Omnibus is a collection of small adventure games.">
 <meta name="twitter:image" content="">
 </head>
 <body>
 <div id="app">
 <header>
-  <h1>AvO: The Adventurers' Omnibus</h1>
+  <h1>AvO: Adventures Omnibus</h1>
 </header>
 <main id="main" tabindex="0">
   <canvas id="canvas"></canvas>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "avo-adventure-mk3",
   "version": "1.0.0",
-  "description": "AvO: The Adventurers' Omnibus is a collection of small adventure games.",
+  "description": "AvO: Adventures Omnibus is a collection of small adventure games.",
   "main": "index.js",
   "scripts": {
     "start": "webpack && sass src:app && node server.js",


### PR DESCRIPTION
## PR Overview

This is a minor content update.

- "The Adventurers' Omnibus" is renamed to "Adventures Omnibus" to avoid using an awkward apostrophe.
- Also I'm somewhat annoyed after accidentally Merging PR 1 instead of Squash-Merging it on Github, so I'm opening a relatively light PR just so I can set Squash-Merging as the new default.